### PR TITLE
Consistent Lane Width and Lane Label Width

### DIFF
--- a/lib/src/views/timetable_view.dart
+++ b/lib/src/views/timetable_view.dart
@@ -142,9 +142,10 @@ class _TimetableViewState extends State<TimetableView>
         shrinkWrap: true,
         children: widget.laneEventsList.map((laneEvents) {
           return Container(
-            width: laneEvents.lane.width,
+            width: widget.timetableStyle.laneWidth,
             height: laneEvents.lane.height,
             color: laneEvents.lane.backgroundColor,
+            // color: Colors.red,
             child: Center(
               child: Text(
                 laneEvents.lane.name,


### PR DESCRIPTION
With reference to Issue #8 . This PR creates a consistent behavior between Lane Width and Lane Label Width. 

They now both use the value of timetableStyle.laneWidth